### PR TITLE
Added the ability to inject middleware into test server

### DIFF
--- a/lib/server/emulate.js
+++ b/lib/server/emulate.js
@@ -19,6 +19,8 @@
  *
  */
 var proxy = require('./proxy'),
+    path = require('path'),
+    fs = require('fs'),
     server = require('./index'),
     colors = require('colors'),
     express = require('express'),
@@ -29,7 +31,7 @@ colors.mode = "console";
 module.exports = {
     start: function (options) {
         var app = server.start(options);
-
+            
         if (!options.path) { options.path = [process.cwd()]; }
 
         if (!options.route) {
@@ -58,8 +60,16 @@ module.exports = {
         app.use(hosted.inject(options));
 
         if (!options.remote) {
-            options.path.forEach(function (path) {
-                app.use("/", express.static(path));
+            options.path.forEach(function (resourcePath) {
+                var resolvedPath = path.resolve(process.cwd(), resourcePath),
+                    customMiddleware = path.join(resolvedPath, 'ripple-middleware.js'),
+                    hasCustomMiddleware = fs.existsSync(customMiddleware);
+
+                if (hasCustomMiddleware) {
+                    require(customMiddleware)(app, resolvedPath);
+                }
+
+                app.use("/", express.static(resolvedPath));
             });
         }
 


### PR DESCRIPTION
Hey Guys,

Just found the ripple cli support, which I'm really excited about using.  In my particular use case, I work a lot with [browserify](https://github.com/substack/node-browserify) as a development tool and there are some useful connect middlewares for "browserfying on the fly".

The pull request involves a modification to the emulate.js handler which looks for a `ripple-middleware.js` file in the path that it is currently emulating.  If found, that file is included and given the opportunity to inject additional middleware into the app.  And example file can be found at the following url:

https://github.com/DamonOehlman/bb10/blob/master/demo/ripple-middleware.js

The code itself looks something like:

``` js
var browserify = require('browserify-middleware'),
    stylify = require('stylify');

browserify.settings({
    transform: [ stylify ]
});

module.exports = function(app, resourcePath) {
    console.log('browserifying on resource path: ' + resourcePath);
    app.use('/', browserify(resourcePath));
};
```

It certainly helps my development workflow, and I'm guessing my also help others.  I've sent through a completed ICLA to Apache, as this is the first project I've contributed to within apache.

Cheers,
Damon.
