### PR TITLE
Cordova 2.0.0 Logger and TouchEvent Fixes

### DIFF
--- a/lib/client/platform/cordova/2.0.0/bridge.js
+++ b/lib/client/platform/cordova/2.0.0/bridge.js
@@ -34,6 +34,7 @@ module.exports = {
             "File": ripple('platform/cordova/2.0.0/bridge/file'),
             "Geolocation": ripple('platform/cordova/2.0.0/bridge/geolocation'),
             "Globalization": ripple('platform/cordova/2.0.0/bridge/globalization'),
+            "Logger": ripple('platform/cordova/2.0.0/bridge/logger'),
             "Media": ripple('platform/cordova/2.0.0/bridge/media'),
             "Network Status": ripple('platform/cordova/2.0.0/bridge/network'),
             "NetworkStatus": ripple('platform/cordova/2.0.0/bridge/network'),

--- a/lib/client/platform/cordova/2.0.0/bridge/logger.js
+++ b/lib/client/platform/cordova/2.0.0/bridge/logger.js
@@ -1,0 +1,26 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+module.exports = {
+    logLevel: function (success, fail, args) {
+        console.log(args.join(":"));
+        return true;
+    }
+};

--- a/lib/client/touchEventEmulator.js
+++ b/lib/client/touchEventEmulator.js
@@ -20,6 +20,7 @@
  */
 
 var utils = ripple('utils'),
+    _lastMouseEvent,
     _isMouseDown,
     _win,
     _doc,
@@ -39,6 +40,13 @@ function _simulateTouchEvent(type, mouseevent) {
     var simulatedEvent,
         touchObj,
         eventData;
+
+    if( _lastMouseEvent &&
+        mouseevent.type === _lastMouseEvent.type &&
+        mouseevent.pageX === _lastMouseEvent.pageX &&
+        mouseevent.pageY === _lastMouseEvent.pageY) return;
+
+    _lastMouseEvent = mouseevent;
 
     touchObj = {
         clientX: mouseevent.pageX,
@@ -63,8 +71,15 @@ function _simulateTouchEvent(type, mouseevent) {
 
     utils.mixin(touchObj, eventData);
 
-    simulatedEvent = _initTouchEvent(type, true, true, eventData);
+    var itemFn = function(index) {
+        return this[index];
+    }
 
+    eventData.touches.item = itemFn;
+    eventData.changedTouches.item = itemFn;
+    eventData.targetTouches.item = itemFn;
+
+    simulatedEvent = _initTouchEvent(type, true, true, eventData);
     mouseevent.target.dispatchEvent(simulatedEvent);
 
     if (typeof mouseevent.target["on" + type] === "function") {


### PR DESCRIPTION
[ADD] Logger to Cordova 2.0.0 bridge
-Fixes Logger.logLevel screen on Cordova 2.9+
[FIX] TouchEvents properly follow spec with TouchList item function.
- many libraries iterate through item on touches, changedTouches, targetTouches (google maps)
  [FIX] Infinite recursion when using Google Map within ripple
- Events compared against previous events for idential location and type.
- Google Maps redispatches touchevents as mouseevents
