### PR TITLE
Change license name to conform to SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://ripple.incubator.apache.org/"
   },
   "licenses": [{
-    "type": "Apache 2.0",
+    "type": "Apache-2.0",
     "url": "http://www.apache.org/licenses/LICENSE-2.0"
   }],
   "repository": {


### PR DESCRIPTION
Was "Apache 2.0" changed to "Apache-2.0" per:

https://spdx.org/licenses/
