### PR TITLE
enable compatibility with phonegap

### DIFF
--- a/lib/server/emulate/hosted.js
+++ b/lib/server/emulate/hosted.js
@@ -162,9 +162,21 @@ function localInjection() {
 
     return function (req, res, next) {
         if (req.query.enableripple && req.staticPlatform) {
-            console.log('refreshing project (platform: ' + req.staticPlatform + ') ...');
+        	console.log('refreshing project (platform: ' + req.staticPlatform + ') ...');
             exec('cordova prepare ' + req.staticPlatform, function () {
-                handle(req, res, next);
+            	    // make ripple compatible with phonegap
+            	    // as of version 3.0 phonegap uses phonegap.js instead of cordova.js
+            	    // but the files are identical 
+                    if(req.query.phonegap) {
+                    	var path = './platforms/' + req.staticPlatform + '/assets/www';
+                    	fs.readFile(path + '/cordova.js', function(err, data) {
+                    		if(err) throw err;
+                    		console.log('... copying cordova.js to phonegap.js')
+                    		fs.writeFileSync(path + '/phonegap.js', data);
+                    	})
+                    }
+                    console.log('... done.');
+                    handle(req, res, next);
             });
         }
         else {


### PR DESCRIPTION
This is in relation to the problem described in http://stackoverflow.com/questions/18178236/cordova-3-ripple, in particular when running phonegap 3.0.0 and ripple. Ripple issues the `cordova prepare` command which rebuilds the www files and removes `phonegap.js`. This fix simply recreates `phonegap.js` if the URI specifies `phonegap=true`.
