### PR TITLE
Fix RIPPLE-60 - proxy not detecting json properly

### DIFF
--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -83,7 +83,7 @@ function proxy(req, res, callback) {
         };
 
         if (Object.keys(req.body).length > 0) {
-            if (req.get("content-type") === "application/json") {
+            if (req.is("json")) {
                 proxyReqData.body = JSON.stringify(req.body);
             } else {
                 proxyReqData.form = req.body;


### PR DESCRIPTION
It didn't support stuff like `Content-Type: application/json;charset=UTF-8` before. Now it does.

Original bug: https://issues.apache.org/jira/browse/RIPPLE-60
