### PR TITLE
Adding build requirements for windows to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ A browser based, platform agnostic mobile application development and testing to
  
 ## Build Requirements
 
-* nodejs, npm
-* OSX or linux (windows is not currently supported for development)
+* OSX / Linux
+ * nodejs, npm
+* Windows
+ * nodejs, npm
+ * [Python](https://www.python.org/downloads/) (`v.2.7.x` recommended, `v.3.x.x` is not supported)
+ * Visual Studio 2010. The setup instructions can be found [here](https://github.com/brianmcd/contextify/wiki/Windows-Installation-Guide)
+ * Ripple uses [Bower](http://bower.io/) for js libraries managing. In order to use Bower on Windows, [msysgit](http://msysgit.github.io/) must be installed in a proper way - see Bower's [README.md](https://github.com/bower/bower#windows-users)
 
 ## Getting Started
 


### PR DESCRIPTION
@brentlintner, Good news! Build for windows was fixed a long time ago - https://github.com/apache/incubator-ripple/commit/416a7fa5571061ff3e430d74cdb5fa8ab3fb7dad . Eventhough it was a bit tricky to build it due to jsdom / contextify visual studio requirement, which must be installed in a subtle way -  https://github.com/brianmcd/contextify/wiki/Windows-Installation-Guide . So, I do believe it's a good idea to update existing README.MD with the windows build requirements.
