### PR TITLE
Changing cursor when there is an ability of moving tool panels

### DIFF
--- a/assets/client/ripple.css
+++ b/assets/client/ripple.css
@@ -334,7 +334,7 @@ section.left { left: 0; }
     right: 7px;
     top: 4px;
     opacity: 0.4;
-    cursor: pointer;
+    cursor: move;
 }
 
 .ui-sortable-highlight {


### PR DESCRIPTION
IMHO, `move` cursor type is more appropriate  - http://youtu.be/wRHs_rXe29Q
