### PR TITLE
Avoid polluting browser console

### DIFF
--- a/lib/client/bootstrap.js
+++ b/lib/client/bootstrap.js
@@ -18,8 +18,7 @@
  * under the License.
  *
  */
-var _bound,
-    _console = ripple('console');
+var _bound;
 
 function _bindObjects(win, doc) {
     if (!win.tinyHippos) {
@@ -42,8 +41,6 @@ function _createFrame(src) {
 function _post(src) {
     var event = ripple('event'),
         frame = _createFrame(src);
-
-    _console.log("Initialization Finished (Make it so.)");
 
     frame.onload = function () {
         var bootLoader = document.querySelector("#emulator-booting"),
@@ -69,8 +66,6 @@ function _bootstrap() {
     if (console.clear) {
         console.clear();
     }
-
-    _console.log("Ripple :: Environment Warming Up (Tea. Earl Gray. Hot.)");
 
     window.tinyHippos = ripple('index');
 


### PR DESCRIPTION
If this is not acceptable, I think one should be able to toggle the extra console noise, or disable parts of it.
