### PR TITLE
RIPPLE-69: Adding cordova-3.6.x support

### DIFF
--- a/lib/client/platform/cordova/3.0.0/spec.js
+++ b/lib/client/platform/cordova/3.0.0/spec.js
@@ -45,6 +45,7 @@ module.exports = {
                 cordova.define.remove("cordova/exec");
                 cordova.define("cordova/exec", function (require, exports, module) {
                     module.exports = bridge.exec;
+                    module.exports.init = module.exports.init || function(){cordova.require('cordova/channel').onNativeReady.fire();} // RIPPLE-69 adding cordova-3.6.x support
                 });
             };
 


### PR DESCRIPTION
Additional notes can be found here - https://issues.apache.org/jira/browse/RIPPLE-69
