### PR TITLE
The ASF comments are showing up in cli help logs.

### DIFF
--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -21,12 +21,17 @@
 
 var fs = require('fs'),
     path = require('path'),
-    colors = require('colors');
+    colors = require('colors'),
+    MD_COMMENTS = /\s*<\!\-\-(.|\n)*\-\-\>\s*/g;
 
 colors.mode = "console";
 
 function style(command) {
-    var raw = fs.readFileSync(path.join(__dirname, '..', '..', 'doc', 'cli', command + ".md")).toString('utf8').split("\n");
+    var raw = fs
+      .readFileSync(path.join(__dirname, '..', '..', 'doc', 'cli', command + ".md"))
+      .toString('utf8')
+      .replace(MD_COMMENTS, "")
+      .split("\n");
 
     return raw.map(function (line) {
         if (line.match(/^# /)) {


### PR DESCRIPTION
The rather interesting way comments are logged does not include
stripping out any comments.

This is a hasty way, although there could be better alternatives
in the future.