### PR TITLE
RIPPLE-78 Unexpected prompt for App.messageChannel with Cordova 4.3.0

### DIFF
--- a/lib/client/platform/cordova/2.0.0/bridge/app.js
+++ b/lib/client/platform/cordova/2.0.0/bridge/app.js
@@ -33,5 +33,9 @@ module.exports = {
 
     overrideBackbutton: function( win, fail, args ) {
         _console.log("Native back button handler was detached.");
+    },
+
+    messageChannel: function () {
+        // NO-OP (exists to support communication from native to JavaScript)
     }
 };


### PR DESCRIPTION
`Cordova 4.3.0` adds a call to `App.messageChannel` during app initialization (on Android). Ripple doesn't know about the `messageChannel` action, and so displays the `I Haz Cheeseburger?!?!` prompt to request a response to the exec call.