### PR TITLE
RIPPLE-79 Cordova Android platform 'App' service renamed 'CoreAndroid'.

### DIFF
--- a/lib/client/platform/cordova/3.0.0/bridge/coreandroid.js
+++ b/lib/client/platform/cordova/3.0.0/bridge/coreandroid.js
@@ -1,0 +1,41 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+var _console = ripple('console');
+
+module.exports = {
+    show: function (success) {
+        return success && success();
+    },
+
+    exitApp: function (win, fail, args) {
+        //window.close();
+        _console.warn("Application must exit now.");
+    },
+
+    overrideBackbutton: function (win, fail, args) {
+        _console.log("Native back button handler was detached.");
+    },
+
+    messageChannel: function () {
+        // NO-OP (exists to support communication from native to JavaScript)
+    }
+};

--- a/lib/client/platform/cordova/3.0.0/spec.js
+++ b/lib/client/platform/cordova/3.0.0/spec.js
@@ -54,10 +54,15 @@ module.exports = {
         bridge.add("InAppBrowser", ripple('platform/cordova/3.0.0/bridge/inappbrowser'));
         bridge.add("Vibration", ripple('platform/cordova/3.0.0/bridge/vibration'));
 
+        // RIPPLE-79 cordova-android 4.0.0 renames 'App' service to 'CoreAndroid'. We'll leave
+        // platform/cordova/2.0.0/bridge/app in place for backwards compatibility, and add CoreAndroid
+        // here for the future.
+        bridge.add("CoreAndroid", ripple('platform/cordova/3.0.0/bridge/coreandroid'));
+
         /** external plugins **/
         // scandit barcode scanner @see https://github.com/Scandit/BarcodeScannerPlugin
         bridge.add("ScanditSDK", ripple('platform/cordova/3.0.0/bridge/scanditsdk'));
-        
+
         // RIPPLE-71 BarcodeScaner plugin support @see https://github.com/phonegap-build/BarcodeScanner 
         bridge.add("BarcodeScanner", ripple('platform/cordova/3.0.0/bridge/barcodescanner'));
 


### PR DESCRIPTION
In cordova-android 4.0.0, the `App` service has been renamed to `CoreAndroid`.

This change adds support for the `CoreAndroid` service - currently identical to the existing `App` bridge, but of course it may change going forwards (while App should remain unchanged, for backwards compatibility).