### PR TITLE
Made jake [lint, build, test] work on windows

### DIFF
--- a/build/lint.js
+++ b/build/lint.js
@@ -26,7 +26,6 @@ function _spawn(proc, args, done) {
     function log(data) {
         process.stdout.write(new Buffer(data).toString("utf-8"));
     }
-
     var cmd = childProcess.spawn(proc, args);
 
     cmd.stdout.on('data', log);
@@ -38,13 +37,13 @@ function _spawn(proc, args, done) {
 }
 
 function _lintJS(files, done) {
-    _spawn('jshint', files, done);
+    _spawn((process.platform === 'win32') ? 'jshint.cmd' : 'jshint', files, done);
 }
 
 function _lintCSS(files, done) {
     var rules = JSON.parse(fs.readFileSync(_c.ROOT + ".csslintrc", "utf-8")),
         options = ["--errors=" + rules, "--format=compact", "--quiet"];
-    _spawn('csslint', files.concat(options), function (/*code*/) {
+    _spawn((process.platform === 'win32') ? 'csslint.cmd' : 'csslint', files.concat(options), function (/*code*/) {
         // TODO: There is a lingering CSS error that can not be turned off.
         //       Once fix, pass code back into this callback.
         done(0);

--- a/build/pack.js
+++ b/build/pack.js
@@ -27,14 +27,15 @@ module.exports = function (opts) {
     var lib = [],
         devicesCSS = [],
         overlays = [],
+        overlayStyles = [],
         panels = [],
         dialogs = [],
         thirdparty = [],
-        slash = !!process.platform.match(/^win/) ? "\\":"/",
         src = {
             info: JSON.parse(fs.readFileSync(_c.PACKAGE_JSON, "utf-8")),
             js: "",
             overlays: "",
+            overlayStyles: "",
             panels: "",
             dialogs: "",
             html: "",
@@ -63,6 +64,7 @@ module.exports = function (opts) {
     utils.collect(_c.LIB, lib);
     utils.collect(_c.DEVICES, devicesCSS, matches(".css"));
     utils.collect(_c.UI, overlays, matches("overlay.html"));
+    utils.collect(_c.UI, overlayStyles, matches("overlay.css"));
     utils.collect(_c.UI, panels, matches("panel.html"));
     utils.collect(_c.UI, dialogs, matches("dialog.html"));
 
@@ -78,6 +80,7 @@ module.exports = function (opts) {
     src.panels += compile(panels);
     src.dialogs += compile(dialogs);
     src.overlays += compile(overlays);
+    src.overlayStyles += compile(overlayStyles);
 
     if (!opts.noclosure) {
         src.js += "(function () {\n";
@@ -90,7 +93,7 @@ module.exports = function (opts) {
     src.js += "window.ripple = ripple;\n";
 
     src.js += compile(lib, function (file, path) {
-        return "ripple.define('" + path.replace(_path.resolve(_c.LIB) + slash, "").replace(/\.js$/, '').replace(/\\/g, "/") +
+        return "ripple.define('" + path.replace(_path.resolve(_c.LIB) + _path.sep, "").replace(/\.js$/, '').replace(/\\/g, '/') +
                "', function (ripple, exports, module) {\n" + file + "});\n";
     });
 

--- a/build/quotes.js
+++ b/build/quotes.js
@@ -43,7 +43,7 @@ var quotes = [
     "Talk is cheap. Show me the code. - Linus Torvalds",
     "Perfection [in design] is achieved, not when there is nothing more to add, but when there is nothing left to take away. - Antoine de Saint-Exupery",
     "C is quirky, flawed, and an enormous success. - Dennis M. Ritchie.",
-    "In theory, theory and practice are the same. In practice, they're not. - Yoggi Berra",
+    "In theory, theory and practice are the same. In practice, they're not. - Yogi Berra",
     "You can't have great software without a great team, and most software teams behave like dysfunctional families. - Jim McCarthy",
     "PHP is a minor evil perpetrated and created by incompetent amateurs, whereas Perl is a great and insidious evil, perpetrated by skilled but perverted professionals. - Jon Ribbens",
     "Programming is like kicking yourself in the face, sooner or later your nose will bleed. - Kyle Woodbury",

--- a/build/utils.js
+++ b/build/utils.js
@@ -29,7 +29,7 @@ _self = module.exports = {
         };
 
         if (fs.statSync(path).isDirectory()) {
-            fs.readdirSync(path).forEach(function (item) {
+            fs.readdirSync(path).sort().forEach(function (item) {
                 _self.collect(_path.join(path, item), files, matches);
             });
         } else if (matches(path)) {


### PR DESCRIPTION
Use csslint.cmd and jshint.cmd on Windows host.
Sort the list of files before building ripple.js; otherwise
ripple.js files built on Linux and Windows don't compare well.
Added .css files below lib/client/ui to the csslint input.
Used path.sep instead of computing a "slash" variable.
Finally, fixed misspelling of the great Yogi Berra's name!