### PR TITLE
Updated jsdom and bower; fixed a test issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "request": "2.12.0"
   },
   "devDependencies": {
-    "bower": "0.9.x",
+    "bower": "1.3.12",
     "connect": "2.3.6",
     "coverjs": "0.0.14",
     "cssmin": "0.3.1",
     "html-minifier": "0.4.5",
-    "jsdom": "0.6.x",
+    "jsdom": "3.1.0",
     "jWorkflow": "0.x.x",
     "semver": "^4.3.1",
     "xmlhttprequest": "1.4.2"

--- a/test/unit/client/cordova/globalization.js
+++ b/test/unit/client/cordova/globalization.js
@@ -92,7 +92,7 @@ describe("cordova globalization bridge", function () {
         });
 
         it("calls moment with the provided date", function () {
-            var date = new Date();
+            var date = args[0].date;
             glob.dateToString(success, fail, args);
             expect(moment).toHaveBeenCalledWith(date);
         });


### PR DESCRIPTION
Updated version of jsdom from 0.6.x to 3.1.0.
The older jsdom fails with a RangeError, saying
"The normalization form should be one of NFC, NFD, NFKC, NFKD."
I tested the newer jsdom with node 0.11.15 and 0.12.0.
I can't get Ripple to install with node 0.10.5, because some modules
require version specifications containing "^", and that form isn't
understood by the version of npm that comes with node 0.10.5.

Also had to update bower to version 1.3.12 for similar reasons.
It wasn't successfully installing jasmine into thirdparty folder.

Finally, fixed a unit test that only passed if two calls to Date returned
the same value.  The calls are close together so this usually works,
but it does cause intermittent failures.