### PR TITLE
RIPPLE-74 Ripple does not pass geolocation info to app.

### DIFF
--- a/lib/client/emulatorBridge.js
+++ b/lib/client/emulatorBridge.js
@@ -76,11 +76,18 @@ module.exports = {
         _doc = doc;
         _xhr = win.XMLHttpRequest;
 
-        var marshal = function (obj, key) {
-                window[key] = win[key] = obj;
-            },
-            currentPlatform = platform.current(),
-            sandbox = {};
+        function marshal(obj, key) {
+            // Use defineProperty, otherwise we won't be able to override built-in read-only properties.
+            Object.defineProperty(window, key, {
+                value: obj
+            });
+            Object.defineProperty(win, key, {
+                value: obj
+            });
+        }
+
+        var currentPlatform = platform.current(),
+            sandbox         = {};
 
         marshal(window.tinyHippos, "tinyHippos");
         marshal(window.XMLHttpRequest, "XMLHttpRequest");


### PR DESCRIPTION
The underlying problem here was that Ripple was failing to patch window.navigator.