### PR TITLE
Fix RIPPLE-83 (broken project refresh)

### DIFF
--- a/lib/server/emulate.js
+++ b/lib/server/emulate.js
@@ -23,6 +23,7 @@ var proxy = require('./proxy'),
     colors = require('colors'),
     express = require('express'),
     cordovaProject = require('./emulate/cordovaProject'),
+    cordovaPrepare = require('./emulate/cordovaPrepare'),
     hosted = require('./emulate/hosted'),
     static = require('./emulate/static');
 
@@ -43,9 +44,7 @@ module.exports = {
         app = proxy.start({route: options.route}, app);
 
         // TODO does not work with custom route (since ripple does not dynamically know custom ones, yet, if set)
-        app.post("/ripple/user-agent", function (req, res/*, next*/) {
-            res.send(200);
-
+        app.post("/ripple/user-agent", function (req, res, next) {
             options.userAgent = unescape(req.body.userAgent);
 
             if (options.userAgent) {
@@ -53,6 +52,7 @@ module.exports = {
             } else {
                 console.log("INFO:".green + ' Using Browser User Agent (String)');
             }
+            next();
         });
 
         // TODO: How to make into a dynamic route (using options.route)? (set at build time right now)
@@ -61,6 +61,7 @@ module.exports = {
         app.use(hosted.inject(options));
 
         if (!options.remote) {
+            app.use("/ripple/user-agent", cordovaPrepare.refresh());
             app.use("/", static.inject(options));
         }
 

--- a/lib/server/emulate/cordovaPrepare.js
+++ b/lib/server/emulate/cordovaPrepare.js
@@ -1,0 +1,61 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+"use strict";
+
+var exec = require('child_process').exec,
+    cordovaPrepare;
+
+try {
+    cordovaPrepare = require.resolve('cordova') ? require('cordova/src/prepare') : null;
+} catch (e) {
+    console.log('INFO: '.green +
+                'Could not find cordova as a local module. Expecting to find it installed globally.');
+}
+
+module.exports = {
+    refresh: function () {
+        return function (req, res /*, next */) {
+
+            var callback = function (err) {
+                if (err) {
+                    console.error('Failed to execute command: cordova prepare. '.red +
+                                  'Make sure you\'ve installed cordova.'.red);
+                    res.status(500).send('Cannot prepare sources for the platform: ' + err);
+                } else {
+                    res.status(200).send('OK');
+                    console.log('... done.');
+                }
+            };
+
+            if (req.staticPlatform) {
+                console.log('refreshing project (platform: ' + req.staticPlatform + ') ...');
+                if (!!cordovaPrepare) {
+                    cordovaPrepare({ platforms: [ req.staticPlatform ] }).then(callback).done();
+                } else {
+                    exec('cordova prepare ' + req.staticPlatform, callback);
+                }
+            } else {
+                res.status(500).send('Cannot prepare: no platform is detected');
+            }
+
+        };
+    }
+};

--- a/lib/server/emulate/hosted.js
+++ b/lib/server/emulate/hosted.js
@@ -130,6 +130,7 @@ function localInjection() {
 
             var doc = data.replace(HEAD_TAG,
                       '<head>' +
+                        '<link rel="icon" href="data:;base64,iVBORw0KGgo=">' +
                         '<script>' +
                             BOOTSTRAP_FROM_IFRAME +
                         '</script>');

--- a/lib/server/emulate/hosted.js
+++ b/lib/server/emulate/hosted.js
@@ -21,7 +21,6 @@
 var fs = require('fs'),
     path = require('path'),
     request = require('request'),
-    exec = require('child_process').exec,
     url = require('url'),
 
     HEAD_TAG = /<\s*head\s*>/,
@@ -125,16 +124,6 @@ function remoteInjection(opts) {
 
 function localInjection() {
 
-    var cordovaPrepare;
-
-    try {
-        cordovaPrepare = require.resolve('cordova') ? require('cordova/src/prepare') : null;
-    }
-    catch (e) {
-        console.log('INFO: '.green +
-            'Could not find cordova as a local module. Expecting to find it installed globally.');
-    }
-
     function inject(file, req, res) {
         fs.readFile(file, "utf-8", function (err, data) {
             if (err) { throw new Error(err); }
@@ -172,40 +161,19 @@ function localInjection() {
     }
 
     return function (req, res, next) {
-
-        var callback = function (err) {
-            if (err) {
-                console.error('Failed to execute command: cordova prepare. '.red +
-                    'Make sure you\'ve installed cordova.'.red);
-            }
-
-            // make ripple compatible with phonegap
-            // as of version 3.0 phonegap uses phonegap.js instead of cordova.js
-            // but the files are identical
-            if (req.query.phonegap) {
-                var path = './platforms/' + req.staticPlatform + '/assets/www';
-                fs.readFile(path + '/cordova.js', function(err, data) {
-                    if(err) throw err;
-                    console.log('... copying cordova.js to phonegap.js');
-                    fs.writeFileSync(path + '/phonegap.js', data);
-                });
-            }
-            console.log('... done.');
-            handle(req, res, next);
-        };
-
-        if (req.query.enableripple && req.staticPlatform) {
-            console.log('refreshing project (platform: ' + req.staticPlatform + ') ...');
-            if (!!cordovaPrepare) {
-                cordovaPrepare({ platforms: [ req.staticPlatform ] }).then(callback).done();
-            }
-            else {
-                exec('cordova prepare ' + req.staticPlatform, callback);
-            }
+        // make ripple compatible with phonegap
+        // as of version 3.0 phonegap uses phonegap.js instead of cordova.js
+        // but the files are identical
+        if (req.query.phonegap) {
+            var path = './platforms/' + req.staticPlatform + '/assets/www';
+            fs.readFile(path + '/cordova.js', function(err, data) {
+                if(err) throw err;
+                console.log('... copying cordova.js to phonegap.js');
+                fs.writeFileSync(path + '/phonegap.js', data);
+            });
         }
-        else {
-            handle(req, res, next);
-        }
+
+        handle(req, res, next);
     };
 }
 


### PR DESCRIPTION
Fix RIPPLE-83: use proper prepare logic.
    
Instead of preparing on a GET in the middleware, prepare when the client
reports a new User-Agent is set (either after the bootstrap or when a device is
changed).
    
Details:
    
1. Propagate POST to /ripple/user-agent through the middleware.
2. Add cordovaPrepare.js whose sole purpose is to respond to platform changes (only for local apps).
3. Remove all the prepare logic from hosted.
4. (Bonus) Prevent requesting site icon for the app iframe.