### PR TITLE
Fix fixwhitespace task.

### DIFF
--- a/build/whitespace.js
+++ b/build/whitespace.js
@@ -29,7 +29,7 @@ var fs = require('fs'),
     path = require("path"),
     rexp_minified = new RegExp("\\.min\\.js$"),
     rexp_src = new RegExp('\\.js$'),
-    _targets = ['lib'];
+    _targets = ['lib', 'build'];
 
 function forEachFile(root, cbFile, cbDone) {
     var count = 0;
@@ -81,7 +81,7 @@ function processWhiteSpace(processor, done) {
                 }
 
                 // eliminate trailing white space
-                src = src.replace(/ +\n/g, '\n');
+                src = src.replace(/[ ]+$/mg, '');
 
                 if (origsrc !== src) {
                     // write it out yo


### PR DESCRIPTION
When a Windows user uses git with `core.autocrlf` option, the files are checked
out using Windows line-endings and converted back to `\n` on commit. The
regular expression corrected wouldn't catch trailing spaces on lines with
`\r\n`. Instead, let the regexp engine to care of line-endings using multiline
regex and end-of-line.

Also, check build files.