### PR TITLE
Improve jake lint.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/*global desc: false, task: false, complete: false, namespace: false */
 var fs = require('fs');
 
 desc("runs jake build");
@@ -27,7 +28,7 @@ task('build', [], require('./build/build'), true);
 desc("test and lint before building (with js compression)");
 task('deploy', [], require('./build/deploy'), true);
 
-desc("run all tests in node with an emulated dom - jake test [path1,path2]");
+desc("run all tests in node with an emulated dom - jake test [path]...");
 task('test', [], function () {
     require('./build/test')(arguments.length > 0 ? 
                 Array.prototype.slice.apply(arguments) : null);
@@ -43,9 +44,9 @@ namespace('test', function () {
 desc("boot test server for running all tests in the browser");
 task('btest', [], require('./build/btest'));
 
-desc("runs jshint + csslint - jake lint [path1] [path2]");
+desc("runs jshint + csslint - jake lint [path]...");
 task('lint', [], function () {
-    require('./build/lint')(complete, Array.prototype.slice.call(arguments));
+    require('./build/lint')(Array.prototype.slice.call(arguments));
 }, true);
 
 desc("show various codebase stats");

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -26,9 +26,9 @@ var lint = require('./lint'),
     fail = fs.readFileSync(_c.THIRDPARTY + "fail.txt", "utf-8");
 
 function ok(code) {
-    if (code || code === 1) {
+    if (code !== 0) {
         process.stdout.write(fail);
-        process.exit(1);
+        process.exit(code);
     }
 }
 


### PR DESCRIPTION
It's impossible to use `jake lint` as a pre-commit hook or in any automation script because it always returns `0` (success) code. This was the main motivation for the change. Additionally, it has some more improvements.

- Fail the task when the process returns error code.
- Run linters in parallel.
- Remove excessive arguments.
- Use `jake.exec()`. This also removes Windows incompatibility.