### PR TITLE
RIPPLE-86 Ripple won't launch on IE or Edge.

### DIFF
--- a/lib/client/bootstrap.js
+++ b/lib/client/bootstrap.js
@@ -75,7 +75,7 @@ function _bootstrap() {
     window.tinyHippos = ripple('index');
 
     tinyHippos.boot(function () {
-        var uri = document.documentURI.replace(/enableripple=[^&]*[&]?/i, "").replace(/[\?&]*$/, "");
+        var uri = document.URL.replace(/enableripple=[^&]*[&]?/i, "").replace(/[\?&]*$/, "");
         _post(uri);
         delete tinyHippos.boot;
     });

--- a/lib/client/ui/plugins/camera.js
+++ b/lib/client/ui/plugins/camera.js
@@ -58,16 +58,14 @@ module.exports = {
             capture.setAttribute("controls",true);
             capture.style.display = "inline";
             capture.style.height = (screen.availHeight - 50) + "px";
-            capture.src = window.webkitURL.createObjectURL(upload.files[0]);
+            capture.src = (window.URL || window.webkitURL).createObjectURL(upload.files[0]);
 
             result.appendChild(capture);
-
 
             take.style.display = "inline";
         });
 
         take.addEventListener('click', function () {
-            //console.log("type", getType());
             event.trigger('captured-' + getType(), [result.firstChild.src, upload.files[0]]);
             module.exports.hide();
         });


### PR DESCRIPTION
Switch to use `document.URL` instead of `document.documentURI`, which isn't supported by IE or Edge.

Also camera plugin UI is broken in IE and Edge - use `window.URL` if it is available, before falling back on `window.webkitURL`.

There are still likely some CSS issues (a bunch of webkit specific stuff in there), but this gives us basic support.