### PR TITLE
Fixed code that throws an exception from UI layer

### DIFF
--- a/lib/client/platform/cordova/2.0.0/spec/events.js
+++ b/lib/client/platform/cordova/2.0.0/spec/events.js
@@ -22,11 +22,10 @@ function _fires(name, data) {
     return function () {
         var win = ripple('emulatorBridge').window();
 
-        if (!win.cordova) {
-            throw "You must have cordova.js included in your projects, to be able to trigger events";
+        if (win && win.cordova) {
+            // Do nothing if we aren't emulating a valid Cordova application
+            win.cordova.fireDocumentEvent(name, data);
         }
-
-        win.cordova.fireDocumentEvent(name, data);
     };
 }
 

--- a/lib/client/ui/plugins/batteryStatus.js
+++ b/lib/client/ui/plugins/batteryStatus.js
@@ -51,9 +51,8 @@ function _updateUI(status) {
 function _fireBatteryEvent(status) {
     var win = ripple('emulatorBridge').window();
 
-    if (!win.cordova) {
-        alert("You must include cordova.js in your project and add the battery-status plugin to use the battery status API");
-    } else if (status) {
+    if (win && win.cordova) {
+        // Do nothing if we aren't emulating a valid Cordova application
         win.cordova.fireWindowEvent("batterystatus", status);
 
         var level = parseInt(status.level);

--- a/lib/client/ui/plugins/batteryStatus.js
+++ b/lib/client/ui/plugins/batteryStatus.js
@@ -52,7 +52,7 @@ function _fireBatteryEvent(status) {
     var win = ripple('emulatorBridge').window();
 
     if (!win.cordova) {
-        throw "You must have cordova.js included in your projects, to be able to trigger events";
+        alert("You must include cordova.js in your project and add the battery-status plugin to use the battery status API");
     } else if (status) {
         win.cordova.fireWindowEvent("batterystatus", status);
 


### PR DESCRIPTION
The JavaScript part of the Battery Status panel threw an exception
if the program under test has no <script> tag for cordova.js.
You is not the right way to handle errors in the UI layer.
This will result in an uncaught exception in the emulator, not in the
program under test.  Use an alert instead to communicate to the user.