### PR TITLE
Fixed RIPPLE-88

### DIFF
--- a/lib/client/emulatorBridge.js
+++ b/lib/client/emulatorBridge.js
@@ -79,10 +79,10 @@ module.exports = {
         function marshal(obj, key) {
             // Use defineProperty, otherwise we won't be able to override built-in read-only properties.
             Object.defineProperty(window, key, {
-                value: obj
+                value: obj, configurable: true, enumerable: true
             });
             Object.defineProperty(win, key, {
-                value: obj
+                value: obj, configurable: true, enumerable: true
             });
         }
 


### PR DESCRIPTION
The previous fix for RIPPLE-74 rendered the properties created by Ripple
both non-configurable and non-enumable.  Making the properties
non-configurable means they cannot be replaced by the program under test,
and it turns out that cordova.js does just this, hence RIPPLE-88.

I marked the new properties as both configureable and enumerable.
The A+ solution would be to test to see if the property being defined
already exists, and if it does, then use the existing metadata values
for writable and enumerable, but I didn't do all that.