### PR TITLE
Fix RIPPLE-95. Regression: option validation is wrong.

### DIFF
--- a/lib/cli/emulate.js
+++ b/lib/cli/emulate.js
@@ -20,35 +20,11 @@
  */
 var self,
     open = require('open'),
-    emulate = require('./../server/emulate'),
-    help = require('./help'),
-    colors = require('colors');
-
-colors.mode = "console";
+    emulate = require('./../server/emulate');
 
 self = {
     call: function (opts) {
-        if (self.validateOptions(opts)) {
-            self.start(opts);
-        } else {
-            console.error(('Options not understood: ' + process.argv.splice(2).join(' ')).red.bold);
-            help.call('emulate');
-        }
-    },
-    validateOptions: function (opts) {
-        if (opts.path && opts.path.length !== 1) {
-            return false;
-        }
-        if (opts.port && opts.port.length !== 1) {
-            return false;
-        }
-        if (opts.remote && opts.remote.length !== 1) {
-            return false;
-        }
-        if (opts.route && opts.route.length !== 1) {
-            return false;
-        }
-        return true;
+        self.start(opts);
     },
     start: function (opts) {
         var app = emulate.start(opts);


### PR DESCRIPTION
Revert "Validate command-line options."

See RIPPLE-95. This is improper validation.

This reverts commit 5fcf93a50ff8eaea96ca8734f2ecb1259b48b5f3.