### PR TITLE
Fixed RIPPLE-100 (battery status event emulation)

### DIFF
--- a/lib/client/ui/plugins/batteryStatus.js
+++ b/lib/client/ui/plugins/batteryStatus.js
@@ -21,6 +21,7 @@
 
 var constants = ripple('constants'),
     db = ripple('db'),
+    lastLevel,
     batteryLevel = document.getElementById(constants.BATTERY_STATUS.LEVEL_VALUE),
     batteryLevelLabel = document.getElementById(constants.BATTERY_STATUS.LEVEL_LABEL),
     isPlugged = document.getElementById(constants.BATTERY_STATUS.IS_PLUGGED_CHECKBOX);
@@ -37,6 +38,7 @@ function _saveStatus(status) {
     if (status) {
         db.save(constants.BATTERY_STATUS.BATTERY_STATUS_KEY, status.level);
         db.save(constants.BATTERY_STATUS.IS_PLUGGED_KEY, status.isPlugged);
+        lastLevel = status.level;
     }
 }
 
@@ -48,29 +50,31 @@ function _updateUI(status) {
     }
 }
 
-function _fireBatteryEvent(status) {
+function _fireBatteryEvent(status, previousLevel) {
     var win = ripple('emulatorBridge').window();
 
     if (win && win.cordova) {
         // Do nothing if we aren't emulating a valid Cordova application
         win.cordova.fireWindowEvent("batterystatus", status);
 
-        var level = parseInt(status.level);
-        if (level === 20 || level === 5) {
-            if (level === 20) {
-                win.cordova.fireWindowEvent("batterylow", status);
-            } else {
-                win.cordova.fireWindowEvent("batterycritical", status);
-            }
+        var newLevel = parseInt(status.level);
+        var oldLevel = parseInt(previousLevel);
+        // Trigger batterycritical/batterylow event if level drops below threshold
+        // Must test threshold values in ascending order for this to work right
+        if ((oldLevel > 5) && (newLevel <= 5)) {
+            win.cordova.fireWindowEvent("batterycritical", status);
+        } else if ((oldLevel > 20) && (newLevel <= 20)) {
+            win.cordova.fireWindowEvent("batterylow", status);
         }
     }
 }
 
 function _processStatusChanged() {
     var status = _getCurrentStatus();
+    var previousLevel = lastLevel; // Read lastLevel BEFORE calling _saveStatus
     _saveStatus(status);
     _updateUI(status);
-    _fireBatteryEvent(status);
+    _fireBatteryEvent(status, previousLevel);
 }
 
 module.exports = {
@@ -81,18 +85,14 @@ module.exports = {
     },
 
     initialize: function() {
-        jQuery("#" + constants.BATTERY_STATUS.LEVEL_VALUE).bind("mouseup", function() {
-            _processStatusChanged();
-        });
-
-        jQuery("#" + constants.BATTERY_STATUS.IS_PLUGGED_CHECKBOX).bind("click", function() {
-            _processStatusChanged();
-        });
+        jQuery("#" + constants.BATTERY_STATUS.LEVEL_VALUE).unbind("mouseup").bind("mouseup", _processStatusChanged);
+        jQuery("#" + constants.BATTERY_STATUS.IS_PLUGGED_CHECKBOX).unbind("click").bind("click", _processStatusChanged);
 
         var status = {
             level: db.retrieve(constants.BATTERY_STATUS.BATTERY_STATUS_KEY) || 100,
-            isPlugged: db.retrieve(constants.BATTERY_STATUS.IS_PLUGGED_KEY) || false,
+            isPlugged: db.retrieve(constants.BATTERY_STATUS.IS_PLUGGED_KEY) || false
         };
+        lastLevel = status.level;
 
         _updateUI(status);
     }


### PR DESCRIPTION
Fixed the logic so that you get a batterycritical event when the battery status changes from above 5 to 5 or below, not just when the battery status changes to exactly 5.  Similarly for batterylow event.  Note that you must test for batterycritical before checking for batterylow, e.g. when slider moves from 25 to 2 you should get batterycritical, not batterylow.

Seemed like overkill to trigger both events at the same time.