### PR TITLE
Fixed RIPPLE-105, emulator of globalization plugin

### DIFF
--- a/lib/client/platform/cordova/2.0.0/bridge/globalization.js
+++ b/lib/client/platform/cordova/2.0.0/bridge/globalization.js
@@ -88,12 +88,14 @@ function parse(str, length, selector) {
 
 module.exports = {
     getLocaleName: function (win) {
-        win({ value: moment.lang() });
+        win({
+            value: platform.current().device.Globalization.locale.localeName[moment.lang()]
+        });
     },
 
     getPreferredLanguage: function (win) {
         win({
-            value: platform.current().device.globalization.locale.options[moment.lang()]
+            value: platform.current().device.Globalization.locale.localeName[moment.lang()]
         });
     },
 

--- a/lib/client/platform/cordova/2.0.0/spec/device.js
+++ b/lib/client/platform/cordova/2.0.0/spec/device.js
@@ -67,13 +67,42 @@ module.exports = {
                 "type": "select",
                 "value": "en"
             },
+            // Please do not confuse internationlization of Ripple itself
+            // with internationalization of the program under test!
+            //
+            // The names below are shown in the Ripple UI.  They identify
+            // the localesi that can be seen by the program under test.
+            // The strings themselves should align with the locale for Ripple.
+            // Since Ripple itself is not yet internationlized, these should
+            // all be in English, not in the language of the selected locale.
+            //
+            // For example, to choose the en-US local, the user selects
+            // "English (US)" and to choose the fr-FR locale, the user select
+            // "French".  In a Ripple that was itself localized for the fr-FR
+            // locale, the user would select "Anglaise (Etats Unis)" to select
+            // en-US and "Francais" to select fr-FR.
             "options": {
-                "en": "English",
+                "en": "English (US)",
                 "en-ca": "English (Canadian)",
                 "fr": "French",
                 "fr-ca": "French (Canadian)",
                 "de": "German",
-                "ru": "Русский"
+                "ru": "Russian"
+            },
+            // Earlier versions of the globalization plugin returned the above
+            // strings as the result from getPreferredLanguage.  Modern versions
+            // return the locale name instead, which is governed by ISO codes,
+            // specifically ISO-639 (language codes) and ISO-3166 (country codes).
+            //
+            // Note also that the string used to specify a locale to the "moment"
+            // package to not necessarily match the ISO standards.
+            "localeName": {
+                "en": 'en-US',
+                "en-ca": 'en-CA',
+                "fr": 'fr-FR',
+                "fr-ca": 'fr-CA',
+                "de": 'de-DE'
+                "ru": 'ru-RU'
             },
             "callback": function (setting) {
                 moment.lang(setting);

--- a/test/unit/client/cordova/globalization.js
+++ b/test/unit/client/cordova/globalization.js
@@ -20,6 +20,7 @@
  */
 describe("cordova globalization bridge", function () {
     var bridge = ripple('emulatorBridge'),
+        platform = ripple('platform'),
         glob, success, fail;
 
     beforeEach(function () {
@@ -36,6 +37,13 @@ describe("cordova globalization bridge", function () {
         fail = jasmine.createSpy("fail");
 
         spyOn(moment, "lang").andReturn("cv");
+        spyOn(platform, "current").andReturn({
+            device: {
+                globalization: {
+                    locale: { localeName: { "cv": "cv-Chuvash" } }
+                }
+            }
+        });
     });
 
     afterEach(function () {
@@ -43,9 +51,9 @@ describe("cordova globalization bridge", function () {
     });
 
     describe("getLocaleName", function () {
-        it("returns the locale on the success callback", function () {
+        it("returns the localeName string for the momentjs locale", function () {
             glob.getLocaleName(success, fail);
-            expect(success).toHaveBeenCalledWith({value: "cv"});
+            expect(success).toHaveBeenCalledWith({value: "cv-Chuvash"});
         });
 
         it("gets the locale from momentjs", function () {
@@ -60,18 +68,19 @@ describe("cordova globalization bridge", function () {
     });
 
     describe("getPreferredLanguage", function () {
-        var platform = ripple('platform');
-
-        it("returns the options string for the momentjs locale", function () {
-            spyOn(platform, "current").andReturn({
-                device: {
-                    globalization: {
-                        locale: { options: { "cv": "Chuvash" } }
-                    }
-                }
-            });
+        it("returns the localeName string for the momentjs locale", function () {
             glob.getPreferredLanguage(success, fail);
-            expect(success).toHaveBeenCalledWith({value: "Chuvash"});
+            expect(success).toHaveBeenCalledWith({value: "cv-Chuvash"});
+        });
+
+        it("gets the locale from momentjs", function () {
+            glob.getPreferredLanguage(success, fail);
+            expect(moment.lang).toHaveBeenCalledWith();
+        });
+
+        it("doesn't call the fail callback", function () {
+            glob.getPreferredLanguage(success, fail);
+            expect(fail).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
This PR fixes the problems described in RIPPLE-105.
After this fix, the Mobile Spec test for the globalization plugin passes
under emulation.  This was not true before.
